### PR TITLE
Call change callback listener when the date changes

### DIFF
--- a/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
+++ b/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
@@ -161,6 +161,7 @@ public class DatePreference extends DialogPreference implements
     if (shouldSave && this.changedValueCanBeNull != null) {
       setTheDate(this.changedValueCanBeNull);
       this.changedValueCanBeNull = null;
+      this.callChangeListener(getDate());
     }
   }
 


### PR DESCRIPTION
I needed my OnPreferenceChangeListener to be called, so I added this call when the dialog is closed function. Maybe this could be upstreamed so other people could use it.
