### PR TITLE
DatePreference ClassCastException fixed and minor improvement

### DIFF
--- a/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
+++ b/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
@@ -136,7 +136,7 @@ public class DatePreference extends DialogPreference implements
   protected void onRestoreInstanceState(Parcelable state) {
     if (state == null || !state.getClass().equals(SavedState.class)) {
       super.onRestoreInstanceState(state);
-      setTheDate(((SavedState) state).dateValue);
+      setTheDate(defaultValue());
     } else {
       SavedState s = (SavedState) state;
       super.onRestoreInstanceState(s.getSuperState());

--- a/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
+++ b/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
@@ -215,6 +215,35 @@ public class DatePreference extends DialogPreference implements
   /**
    * Produces the date the user has selected for the given preference, as a
    * calendar.
+   *
+   * @param preferences
+   *          the SharedPreferences to get the date from
+   * @param field
+   *          the name of the preference to get the date from
+   * @param defaultDate
+   * the default date to use in case no preference is already saved
+   * @return a Calendar that the user has selected
+   */
+  public static Calendar getDateFor(SharedPreferences preferences, String field, Date defaultDate) {
+    String defaultString = defaultDate != null ? formatter().format(defaultDate) : "";
+    String persisted = preferences.getString(field, defaultString);
+    Date date;
+    if ("".equals(persisted)) {
+      if (defaultDate == null) {
+        return null;
+      } // if
+      date = defaultDate;
+    } else {
+      date = stringToDate(persisted);
+    } // if/else
+    Calendar cal = Calendar.getInstance();
+    cal.setTime(date);
+    return cal;
+  }
+
+  /**
+   * Produces the date the user has selected for the given preference, as a
+   * calendar.
    * 
    * @param preferences
    *          the SharedPreferences to get the date from


### PR DESCRIPTION
Hi,

I fixed a ClassCastException in DatePreference which occured if the device was rotated while the DatePreference was shown. I don't know Android well enough to know why the Parcelable state in onRestoreInstanceState is not the correct SavedState class, but I know that the current code must fail with a ClassCastException (you checked for the class, and casted after you knew it wasn't of the correct type).

I also added an overload for getDateFor() that allows specifying a default value to use in case the DatePreference was never opened in a PreferenceScreen before, as in this case it will always use the default value 1970-01-01.

Hope you find the changes useful.

Best regards,
Martin
