### PR TITLE
no calendarView as 'year chooser' on 4.4 any more

### DIFF
--- a/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
+++ b/DatePreference/src/org/bostonandroid/datepreference/DatePreference.java
@@ -43,6 +43,7 @@ public class DatePreference extends DialogPreference implements
     Calendar calendar = getDate();
     datePicker.init(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH),
         calendar.get(Calendar.DAY_OF_MONTH), this);
+	datePicker.setCalendarViewShown(false); /* else shows day + month + (calendarview instead of year) on api v19/4.4 */
     return datePicker;
   }
 


### PR DESCRIPTION
Without this, the result was a calendarView in place of the year chooser.
Tested on 4.4 ONLY
Now, shows a 'rolling' year chooser.

Thanks for your library.
Still amazed there is no default way to choose a date in the preferences.
